### PR TITLE
Missing SCRIPT_VERIFY_STRICTENC flag will cause replay attack

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1637,6 +1637,7 @@ static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consens
 
     // If the sbtc fork is enabled
     if (IsSBTCForkEnabled(consensusparams, pindex->pprev)) {
+          flags |= SCRIPT_VERIFY_STRICTENC;
           flags |= SCRIPT_ENABLE_SIGHASH_SBTC_FORK;
     }
 


### PR DESCRIPTION
Once the fork has activated, transactions shall be validated with SCRIPT_VERIFY_STRICTENC flag set.

ref: https://github.com/bitcoincashorg/spec/blob/master/uahf-technical-spec.md